### PR TITLE
[bot] Update bot to manage helper role

### DIFF
--- a/bots/feature-watcher/config.js.sample
+++ b/bots/feature-watcher/config.js.sample
@@ -4,6 +4,8 @@ module.exports = {
 
     watchChannel: '',
     watchEmoji: '',
+
+    helperRole: '',
   },
 
   github: {

--- a/bots/feature-watcher/index.js
+++ b/bots/feature-watcher/index.js
@@ -109,14 +109,14 @@ async function createIssue(content, shortName, longName, date) {
     }
   })
 
-  discordClient.on('message', async (processMessage(discordClient)))
+  discordClient.on('message', processMessage(discordClient))
 
   // Login with the Discord App token
   discordClient.login(cfg.discord.token);
 })()
 
 function processMessage(client) {
-  return (message) => {
+  return async function(message) {
     const { cleanContent, member } = message
     // no guild membor found
     if (!member) { return }
@@ -126,14 +126,12 @@ function processMessage(client) {
     // not a command
     if (!isOffcall && !isOncall) { return }
 
-    // TODO: replace ID usage with cfg.discord.helperRole
-
     if (isOncall) {
-      member.addRole('420536763702837250', 'self-requested')
+      member.addRole(cfg.discord.helperRole, 'self-requested')
     }
 
     if (isOffcall) {
-      member.removeRole('420536763702837250', 'self-requested')
+      member.removeRole(cfg.discord.helperRole, 'self-requested')
     }
   }
 }

--- a/bots/feature-watcher/index.js
+++ b/bots/feature-watcher/index.js
@@ -109,6 +109,31 @@ async function createIssue(content, shortName, longName, date) {
     }
   })
 
+  discordClient.on('message', async (processMessage(discordClient)))
+
   // Login with the Discord App token
   discordClient.login(cfg.discord.token);
 })()
+
+function processMessage(client) {
+  return (message) => {
+    const { cleanContent, member } = message
+    // no guild membor found
+    if (!member) { return }
+
+    const isOncall = cleanContent === '!oncall'
+    const isOffcall = cleanContent === '!offcall'
+    // not a command
+    if (!isOffcall && !isOncall) { return }
+
+    // TODO: replace ID usage with cfg.discord.helperRole
+
+    if (isOncall) {
+      member.addRole('420536763702837250', 'self-requested')
+    }
+
+    if (isOffcall) {
+      member.removeRole('420536763702837250', 'self-requested')
+    }
+  }
+}


### PR DESCRIPTION
Updates the bot behavior to stub out what some super basic command support would look like. Started with `!oncall` & `!offcall` which will add/remove the `Ping for Help` role from the commanding user.

This has already gone live and been tested.